### PR TITLE
Add data science dev container link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ Here are some links to these sharing artifacts:
 
 - [Dev Approach Data Projects](https://ssrikantan.github.io/blog/2021/04/08/dev-approach-data-projects)
 - [Why you might want to have an end to end walkthrough document in your repo](https://blog.3-4.fr/2021/04/12/end-to-end-walkthrough/)
+- [Using Visual Studio Code with Data Science dev containers](https://github.com/flecoqui/data-dev-container)


### PR DESCRIPTION
Add data science dev container link in the main documentation.
The repository containing the data science dev container is available here: https://github.com/flecoqui/data-dev-container